### PR TITLE
docs: fix aio-script link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of useful command for your homelab
 Download and execute the script. Answer the questions asked by the script and it will take care of the rest.
 
 ```bash
-curl -O https://raw.githubusercontent.com/Lynnx095/TalenanHidup/refs/heads/main/aio-script.sh
+curl -O https://raw.githubusercontent.com/Lynnx095/TalenanHidup/main/aio-script.sh
 chmod +x aio-script.sh
 ./aio-script.sh
 ```


### PR DESCRIPTION
## Summary
- fix direct download link for aio-script

## Testing
- `npx markdownlint-cli README.md` *(fails: 403 Forbidden)*
